### PR TITLE
Fix trivial doc typo: bin_parser -> bin-parser.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -36,5 +36,5 @@ To convert a YAML file to binary, use the ``write`` subcommand:
 
 ::
 
-    ./node_modules/.bin/bin_parser write input.yml structure.yml types.yml \
+    ./node_modules/.bin/bin-parser write input.yml structure.yml types.yml \
       output.bin


### PR DESCRIPTION
In the CLI section of the docs the example for the `write` command with the JS version incorrectly references `bin_parser`.

This PR fixes this to `bin-parser` as specified in `package.json`.

Related to openjournals/joss-reviews#766.