### PR TITLE
Fix minor typos in usage docs.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -39,8 +39,9 @@ To convert a YAML file to binary, use the ``write`` subcommand:
     ./node_modules/.bin/bin-parser write input.yml structure.yml types.yml \
       output.bin
 
-Please note that when installing from source, the ``bin_parser`` executable is
+Please note that when installing from source, the ``bin-parser`` executable is
 not installed. Instead run the script ``cli.js`` as follows:
 
 ::
+
     nodejs javascript/cli.js


### PR DESCRIPTION
The RST didn't seem to be building correctly at RtD so I've tried to fix that, and `bin_parser` -> `bin-parse` for the JS version as it uses the hyphen, not underscore.

Relates to openjournals/joss-reviews#766.