### PR TITLE
adjust extras/test.sh shebang for wider compatibility

### DIFF
--- a/extras/test.sh
+++ b/extras/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Test whether the YAML produced by the JavaScript version equals that of the
 # Python version.


### PR DESCRIPTION
On some Linux and BSD distributions Bash is not installed at /bin/bash but
rather somewhere like /usr/local/bin/bash. Using /usr/bin/env in this shell
script's shebang lets us find it wherever it is.

This is something I came across while working on #8.